### PR TITLE
Add links to shared_configs files

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -23,7 +23,7 @@ Capistrano::OneTimeKey.generate_one_time_key!
 # set :pty, true
 
 # Default value for :linked_files is []
-# append :linked_files, "config/database.yml", "config/secrets.yml"
+append :linked_files, "config/config.sh"
 
 # Default value for linked_dirs is []
 append :linked_dirs, 'log', 'loc_marc2bibframe2'


### PR DESCRIPTION
This will link the deployed config file to {app}/shared/config/config.sh and this file will be made available from a shared_configs repo.  In testing this deployment, it works OK, given that I put the shared config file in the right place (we can work out dev-ops details later), i.e.

```
00:08 deploy:symlink:linked_files
      01 mkdir -p /opt/app/ld4p/ld4p-marcxml-to-bibframe2/releases/20170308221435/config
    ✔ 01 ld4p@sul-ld4p-converter-dev.stanford.edu 0.050s
      02 rm /opt/app/ld4p/ld4p-marcxml-to-bibframe2/releases/20170308221435/config/config.sh
    ✔ 02 ld4p@sul-ld4p-converter-dev.stanford.edu 0.039s
      03 ln -s /opt/app/ld4p/ld4p-marcxml-to-bibframe2/shared/config/config.sh /opt/app/ld4p/ld4p-marcxml-to-bibframe2/releases/20170308221435/config/config.sh
    ✔ 03 ld4p@sul-ld4p-converter-dev.stanford.edu 0.041s
```
